### PR TITLE
Site metadata saving. 

### DIFF
--- a/R/functions/Site_metadata.R
+++ b/R/functions/Site_metadata.R
@@ -102,7 +102,7 @@ get_ornl_site_codes <- function() {
 
     table <- page_html %>% html_node("#historical_site_list") %>% html_table()
 
-    site_codes = table["FLUXNET ID"]
+    site_codes <- table[["FLUXNET ID"]]
 
     return(site_codes)
 
@@ -111,20 +111,20 @@ get_ornl_site_codes <- function() {
 
 #' Get a single ORNL site URL from site_status table
 get_site_ornl_url <- function(site_code) {
-    ornl_url <- get_site_ornl_urls(list(site_code))[[site_code]]
+    ornl_url <- get_ornl_site_url_list(list(site_code))[[site_code]]
     return(ornl_url)
 }
 
 
 #' Get a list of ORNL site URLs from site_status table
-get_site_ornl_urls <- function(site_code_list) {
+get_ornl_site_url_list <- function(site_code_list) {
     status_table_url <- "https://fluxnet.ornl.gov/site_status"
 
     page_html <- read_html(status_table_url)
 
     ornl_url_list <- list()
 
-    for (sc in site_code_list) {
+    for (site_code in site_code_list) {
         # looks for table cell with site code as contents, then looks up the parent
         # row, and finds the href of the first link.
         xpath =  paste0("//td[text()='", site_code, "']/..")
@@ -132,7 +132,7 @@ get_site_ornl_urls <- function(site_code_list) {
             html_node("a") %>%
             html_attr("href")
 
-        ornl_url_list[[sc]] <- paste0("https://fluxnet.ornl.gov/", ornl_rel_url)
+        ornl_url_list[[site_code]] <- paste0("https://fluxnet.ornl.gov/", ornl_rel_url)
     }
 
     return(ornl_url_list)
@@ -142,11 +142,13 @@ get_site_ornl_urls <- function(site_code_list) {
 #' Get metadata from ORNL
 #'
 #' @return metadata list
-get_site_metadata_ornl <- function(metadata) {
+get_ornl_site_metadata <- function(metadata, site_url=NULL) {
     site_code <- get_site_code(metadata)
 
-    site_url <- get_site_ornl_url(site_code)
-    metadata$ORNL_URL <- site_url
+    if (is.null(site_url)) {
+        site_url <- get_site_ornl_url(site_code)
+        metadata$ORNL_URL <- site_url
+    }
 
     message("Trying to load metadata for ", site_code, " from ORNL (", site_url, ")")
 
@@ -166,9 +168,14 @@ get_site_metadata_ornl <- function(metadata) {
     metadata$SiteLongitude <- as.numeric(lat_lon[1])
 
     # Site Characteristics
-    table <- page_html %>% html_node("table#fluxnet_site_characteristics") %>% html_table()
-    metadata$SiteElevation <- table[table[1] == "GTOPO30 Elevation:"][2]
-    metadata$IGBP_vegetation_long <- table[table[1] == "IGBP Land Cover:"][2]
+    tryCatch({
+        table <- page_html %>% html_node("table#fluxnet_site_characteristics") %>% html_table()
+        metadata$SiteElevation <- table[table[1] == "GTOPO30 Elevation:"][2]
+        metadata$IGBP_vegetation_long <- table[table[1] == "IGBP Land Cover:"][2]
+    }, error = function(cond) {
+        message(site_code, " doesn't have a Site Characteristics table at ", site_url)
+    })
+
     # ORNL doesn't have any of these:
     #    metadata$IGBP_vegetation_short = NULL,
     #    metadata$TowerHeight = NaN,
@@ -188,7 +195,7 @@ get_site_metadata_ornl <- function(metadata) {
 #'
 #' @return metadata list
 get_site_metadata_web <- function(metadata) {
-    metadata <- get_site_metadata_ornl(metadata)
+    metadata <- get_ornl_site_metadata(metadata)
 
     # TODO: Add loaders for OzFlux, AmeriFlux, etc.
 

--- a/R/functions/Site_metadata.R
+++ b/R/functions/Site_metadata.R
@@ -98,7 +98,6 @@ save_metadata_to_csv <- function(metadata) {
 
 #' Write multiple site metadata to list at once
 save_metadata_list_to_csv <- function(metadata_lists) {
-    site_code <- metadata$SiteCode
 
     to_save <- list("SiteCode", "Fullname", "Description", "TowerStatus",
                     "Country", "SiteLatitude", "SiteLongitude", "SiteElevation",
@@ -111,6 +110,7 @@ save_metadata_list_to_csv <- function(metadata_lists) {
                          row.names = 1)
 
     for (metadata in metadata_lists) {
+        site_code <- metadata$SiteCode
         for (v in to_save) {
             if (v %in% names(metadata) & !is.na(metadata[[v]])) {
                 csv_data[site_code, v] <- metadata[[v]]
@@ -150,7 +150,7 @@ get_ornl_site_codes <- function() {
 
     table <- page_html %>% html_node("#historical_site_list") %>% html_table()
 
-    site_codes <- table[["FLUXNET ID"]]
+    site_codes <- sort(table[["FLUXNET ID"]])
 
     return(site_codes)
 

--- a/R/functions/Site_metadata.R
+++ b/R/functions/Site_metadata.R
@@ -19,17 +19,17 @@ library(rvest)  # read_html, html_node, html_attr, html_table
 site_metadata_template <- function(site_code) {
     metadata <- list(
         SiteCode = site_code,
-        Fullname = NULL,
-        SiteLatitude = NaN,
-        SiteLongitude = NaN,
-        SiteElevation = NaN,
-        IGBP_vegetation_short = NULL,
-        IGBP_vegetation_long = NULL,
-        TowerHeight = NaN,
-        CanopyHeight = NaN,
-        Tier = NaN,
+        Fullname = NA,
+        SiteLatitude = NA,
+        SiteLongitude = NA,
+        SiteElevation = NA,
+        IGBP_vegetation_short = NA,
+        IGBP_vegetation_long = NA,
+        TowerHeight = NA,
+        CanopyHeight = NA,
+        Tier = NA,
         Exclude = FALSE,
-        Exclude_reason = NULL
+        Exclude_reason = NA
     )
 
     return(metadata)

--- a/R/functions/Site_metadata.R
+++ b/R/functions/Site_metadata.R
@@ -61,15 +61,16 @@ add_processing_metadata <- function(metadata) {
 # CSV-stored metadata
 ################################################
 
+# TODO: use system.file("help", "aliases.rds", package="FLUXNETProcessing")
+# when this is a proper package.
+# https://stackoverflow.com/questions/3433603/parsing-command-line-arguments-in-r-scripts
+site_csv_file <- "./R/auxiliary_data/Site_info_tier1_only.csv"
+
+
 #' Tries to gather metadata from the included site CSV
 #'
 #' @return metadata list
 get_site_metadata_CSV <- function(metadata) {
-
-    # TODO: use system.file("help", "aliases.rds", package="FLUXNETProcessing")
-    # when this is a proper package.
-    # https://stackoverflow.com/questions/3433603/parsing-command-line-arguments-in-r-scripts
-    site_csv_file <- "./R/auxiliary_data/Site_info_tier1_only.csv"
 
     cat(paste0("Trying to load metadata from csv cache (", site_csv_file, ")"), "\n")
 

--- a/R/functions/Site_metadata.R
+++ b/R/functions/Site_metadata.R
@@ -72,7 +72,7 @@ site_csv_file <- "./R/auxiliary_data/Site_info_tier1_only.csv"
 #' @return metadata list
 get_site_metadata_CSV <- function(metadata) {
 
-    cat(paste0("Trying to load metadata from csv cache (", site_csv_file, ")"), "\n")
+    message("Trying to load metadata from csv cache (", site_csv_file, ")")
 
     site_code <- get_site_code(metadata)
 
@@ -148,7 +148,7 @@ get_site_metadata_ornl <- function(metadata) {
     site_url <- get_site_ornl_url(site_code)
     metadata$ORNL_URL <- site_url
 
-    cat(paste0("Trying to load metadata from ORNL (", site_url, ")"), "\n")
+    message("Trying to load metadata for ", site_code, " from ORNL (", site_url, ")")
 
     page_html <- read_html(site_url)
 
@@ -218,8 +218,8 @@ warn_missing_metadata <- function(metadata) {
     missing_data <- check_missing(metadata)
 
     if (any(missing_data)) {
-        cat(paste("Missing metadata for site ", metadata$SiteCode, ":"), "\n")
-        cat("   ", paste(names(metadata)[missing_data], collapse = ", "), "\n")
+        message("Missing metadata for site ", metadata$SiteCode, ":")
+        message("   ", paste(names(metadata)[missing_data], collapse = ", "))
     }
 }
 


### PR DESCRIPTION
Extension of https://github.com/aukkola/FLUXNET2015_processing/pull/1

Allows saving web-scaped data into CSV, will only update data that's found (e.g. keep manually entered stuff like exclusion/exclusion reasons).

Writing to CSV is not enabled by default.

Also includes and `update_csv_from_ornl` function to rip all CSV data from ORNL. This could be run every now and then, and the included csv updated in the repo (function takes about half an hour, due to all of the web page loading). It shouldn't be hard to extend this to ameriflux, ozflux, etc. if we want to.
