### PR TITLE
Hacky gitrev

### DIFF
--- a/R/Site_metadata.R
+++ b/R/Site_metadata.R
@@ -1,5 +1,4 @@
 # Author: ned haughton
-# Date: 2017-02-17
 
 # Uses rvest library for read_html, html_node, html_attr, html_table
 
@@ -42,7 +41,7 @@ get_site_code <- function(metadata){
 #' Gets the git version from the installed package
 #' See src/zzz.R for how git revision is discovered
 get_git_version <- function() {
-    desc <- system.file("DESCRIPTION", package = "FluxnetProcessing")
+    desc <- read.dcf(system.file("DESCRIPTION", package = "FluxnetProcessing"))
     if ("git_revision" %in% colnames(desc)) {
         git_rev <- desc[1, "git_revision"]
     } else if ("RemoteSha" %in% colnames(desc)) {
@@ -64,6 +63,7 @@ add_processing_metadata <- function(metadata) {
     metadata$Processing <- list(
         processor = "FluxnetProcessing",
         URL = "https://github.com/aukkola/FLUXNET2015_processing",
+        version = packageVersion("FluxnetProcessing"),
         git_rev = get_git_version()
     )
 
@@ -104,7 +104,7 @@ update_metadata <- function(metadata, new_metadata, overwrite=TRUE) {
 #Find site info file path (not using data() command directly because reads a CSV with a
 #semicolon separator and this leads to incorrect table headers)
 
-site_csv_file <- system.file("data","Site_metadata.csv",package="FluxnetProcessing")
+site_csv_file <- system.file("data", "Site_metadata.csv", package = "FluxnetProcessing")
 
 #' Tries to gather metadata from the included site CSV
 #'
@@ -169,7 +169,7 @@ save_metadata_list_to_csv <- function(metadata_lists) {
 update_csv_from_ornl <- function() {
     ornl_site_codes <- get_ornl_site_codes()
     ornl_url_list <- get_ornl_site_url_list(ornl_site_codes)
-    message(length(ornl_url_list), ' sites found.')
+    message(length(ornl_url_list), " sites found.")
 
     metadata_lists <- list()
     for (site_code in ornl_site_codes) {

--- a/R/Site_metadata.R
+++ b/R/Site_metadata.R
@@ -39,6 +39,23 @@ get_site_code <- function(metadata){
 }
 
 
+#' Gets the git version from the installed package
+#' See src/zzz.R for how git revision is discovered
+get_git_version <- function() {
+    desc <- system.file("DESCRIPTION", package = "FluxnetProcessing")
+    if ("git_revision" %in% colnames(desc)) {
+        git_rev <- desc[1, "git_revision"]
+    } else if ("RemoteSha" %in% colnames(desc)) {
+        git_rev <- desc[1, "RemoteSha"]
+    } else {
+        git_rev <- "UNKNOWN"
+        warning("Unknown git revision of FluxnetProcessing.
+    Please visit https://github.com/aukkola/FLUXNET2015_processing and review the installation procedure")
+    }
+    return(git_rev)
+}
+
+
 #' Adds processor metadata, including processor version
 #'
 #' @return metadata list
@@ -47,8 +64,7 @@ add_processing_metadata <- function(metadata) {
     metadata$Processing <- list(
         processor = "FluxnetProcessing",
         URL = "https://github.com/aukkola/FLUXNET2015_processing",
-        # TODO: add git tags if we start using them.
-        git_rev = system("git rev-parse --verify HEAD", intern = TRUE)
+        git_rev = get_git_version()
     )
 
     return(metadata)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,7 @@
+
+build: 
+	Rscript zzz.R
+
+install: 
+	Rscript zzz.R
+

--- a/src/zzz.R
+++ b/src/zzz.R
@@ -1,0 +1,12 @@
+
+git_rev <- system("git rev-parse --verify HEAD", intern = TRUE)
+
+message('git rev: ', git_rev)
+
+desc <- read.dcf("../DESCRIPTION")
+
+update <- matrix(git_rev, dimnames = list(NULL, "git_revision"))
+
+desc <- cbind(desc, update)
+
+write.dcf(desc, "../DESCRIPTION")

--- a/src/zzz.R
+++ b/src/zzz.R
@@ -1,12 +1,25 @@
+#!/usr/bin/env Rscript
 
+# Get git revision
 git_rev <- system("git rev-parse --verify HEAD", intern = TRUE)
 
-message('git rev: ', git_rev)
+if (length(git_rev) == 0) {
+    # Not a git repository!
+    git_rev <- "NON-GIT"
+} else {
+    porcelain <- (system("git status --porcelain", intern = TRUE))
+    if (length(porcelain) > 0) {
+        git_rev <- paste0(git_rev, "-dirty")
+    }
+}
+
+message("git rev: ", git_rev)
 
 desc <- read.dcf("../DESCRIPTION")
-
-update <- matrix(git_rev, dimnames = list(NULL, "git_revision"))
-
-desc <- cbind(desc, update)
-
+if ("git_revision" %in% colnames(desc)) {
+    desc[1, "git_revision"] <- git_rev
+} else {
+    update <- matrix(git_rev, dimnames = list(NULL, "git_revision"))
+    desc <- cbind(desc, update)
+}
 write.dcf(desc, "../DESCRIPTION")


### PR DESCRIPTION
Attempts to get the git rev and add it to the package on install. Warns if git rev can't be found at run time, and tells the user to visit the website for install info.

