### PR TITLE
Limit vars

### DIFF
--- a/R/ConvertSpreadsheetToNcdf.R
+++ b/R/ConvertSpreadsheetToNcdf.R
@@ -126,28 +126,23 @@ convert_fluxnet_to_netcdf <- function(site_code, infile, era_file=NA, out_path,
   }
   
   
-  vars <- read.csv(var_file, header=TRUE,
-                   colClasses=c(
-                                "character",  # Fluxnet_variable
-                                "character",  # Fluxnet_unit
-                                "character",  # Fluxnet_class
-                                "character",  # Output_variable
-                                "character",  # Output_unit
-                                "character",  # Longname
-                                "character",  # Standard_name
-                                "numeric",    # Data_min
-                                "numeric",    # Data_max
-                                "logical",    # Essential_met
-                                "logical",    # Preferred_eval
-                                "character",  # Category
-                                "character",  # ERAinterim_variable
-                                "character"   # Aggregate_method
-                                ))
-
-  if(is.character(conv_opts$limit_vars) & length(conv_opts$limit_vars) > 0){
-    limit_vars <- c(conv_opts$limit_vars, paste0(conv_opts$limit_vars, '_qc'))
-    vars <- vars[vars[['Output_variable']] %in% limit_vars, ]
-  }
+  vars_csv <- read.csv(var_file, header=TRUE,
+                       colClasses=c(
+                                    "character",  # Fluxnet_variable
+                                    "character",  # Fluxnet_unit
+                                    "character",  # Fluxnet_class
+                                    "character",  # Output_variable
+                                    "character",  # Output_unit
+                                    "character",  # Longname
+                                    "character",  # Standard_name
+                                    "numeric",    # Data_min
+                                    "numeric",    # Data_max
+                                    "logical",    # Essential_met
+                                    "logical",    # Preferred_eval
+                                    "character",  # Category
+                                    "character",  # ERAinterim_variable
+                                    "character"   # Aggregate_method
+                                    ))
 
 
   #Read site information (lon, lat, elevation)
@@ -177,7 +172,7 @@ convert_fluxnet_to_netcdf <- function(site_code, infile, era_file=NA, out_path,
   
   
   # Read text file containing flux data
-  DataFromText <- ReadCSVFluxData(fileinname=infile, vars=vars, 
+  DataFromText <- ReadCSVFluxData(fileinname=infile, vars=vars_csv, 
                                   datasetname=conv_opts$datasetname,
                                   time_vars=time_vars, site_log,
                                   fair_usage=conv_opts$fair_use,

--- a/R/ConvertSpreadsheetToNcdf.R
+++ b/R/ConvertSpreadsheetToNcdf.R
@@ -127,13 +127,24 @@ convert_fluxnet_to_netcdf <- function(site_code, infile, era_file=NA, out_path,
   
   
   vars <- read.csv(var_file, header=TRUE,
-                   colClasses=c("character", "character", "character",
-                                "character", "character", "character",
-                                "character", "numeric", "numeric",
-                                "logical", "logical", "character"))
-  
-  
-  
+                   colClasses=c(
+                                "character",  # Fluxnet_variable
+                                "character",  # Fluxnet_unit
+                                "character",  # Fluxnet_class
+                                "character",  # Output_variable
+                                "character",  # Output_unit
+                                "character",  # Longname
+                                "character",  # Standard_name
+                                "numeric",    # Data_min
+                                "numeric",    # Data_max
+                                "logical",    # Essential_met
+                                "logical",    # Preferred_eval
+                                "character",  # Category
+                                "character",  # ERAinterim_variable
+                                "character"   # Aggregate_method
+                                ))
+
+
   #Read site information (lon, lat, elevation)
   site_info <- get_site_metadata(site_code)
   

--- a/R/ConvertSpreadsheetToNcdf.R
+++ b/R/ConvertSpreadsheetToNcdf.R
@@ -162,7 +162,7 @@ convert_fluxnet_to_netcdf <- function(site_code, infile, era_file=NA, out_path,
   #This option is set in the site info file (inside data folder)
   #Mainly excludes sites with mean annual ET excluding P, implying
   #irrigation or other additional water source.
-  if(site_info$Exclude){
+  if(!is.null(site_info$Exclude) & site_info$Exclude){
     
     error <- paste("Site not processed. Reason:", site_info$Exclude_reason,
                    ". This is set in site info file, change >Exclude< options",
@@ -248,7 +248,9 @@ convert_fluxnet_to_netcdf <- function(site_code, infile, era_file=NA, out_path,
       #Gapfill with ERAinterim
       DataFromText <- GapfillMet_with_ERA(DataFromText, era_file,
                                           qc_name, dataset_vars,
-                                          qc_flags=qc_flags)
+                                          qc_flags=qc_flags,
+                                          site_log=site_log)
+      # Not sure if we need to return the site_log from this function? Seems to stop on every error anyway..
       
       #Cannot recognise method, stop
     } else {

--- a/R/ConvertSpreadsheetToNcdf.R
+++ b/R/ConvertSpreadsheetToNcdf.R
@@ -514,15 +514,14 @@ convert_fluxnet_to_netcdf <- function(site_code, infile, era_file=NA, out_path,
 
     # Limit Flux output vars, if necessary
     if (!is.na(conv_opts$limit_vars[1])) {
-        flux_limit_ind <- sapply(flux_ind, function(x) {
+        flux_limit_ind <- sapply(flux_ind[[k]], function(x) {
             if (DataFromText$out_vars[x] %in% conv_opts$limit_vars) {x} else {NA}
         })
         flux_limit_ind <- flux_limit_ind[!is.na(flux_limit_ind)]
     } else {
-        flux_limit_ind <- flux_ind
+        flux_limit_ind <- flux_ind[[k]]
     }
 
-    
     #Write flux file
     CreateFluxNetcdfFile(fluxfilename=fluxfilename, datain=DataFromText,
                          site_code=site_code,
@@ -530,11 +529,11 @@ convert_fluxnet_to_netcdf <- function(site_code, infile, era_file=NA, out_path,
                          ind_start=gaps$tseries_start[k],
                          ind_end=gaps$tseries_end[k],
                          starttime=nc_starttime,
-                         total_missing=gaps$total_missing[[k]][flux_limit_ind[[k]]],
-                         total_gapfilled=gaps$total_gapfilled[[k]][flux_limit_ind[[k]]],
+                         total_missing=gaps$total_missing[[k]][flux_limit_ind],
+                         total_gapfilled=gaps$total_gapfilled[[k]][flux_limit_ind],
                          qcInfo=qc_flags$qc_info,
                          arg_info=arg_info,
-                         var_ind=flux_limit_ind[[k]],
+                         var_ind=flux_limit_ind,
                          modelInfo=model_params)
     
   }

--- a/R/ConvertSpreadsheetToNcdf.R
+++ b/R/ConvertSpreadsheetToNcdf.R
@@ -144,6 +144,11 @@ convert_fluxnet_to_netcdf <- function(site_code, infile, era_file=NA, out_path,
                                 "character"   # Aggregate_method
                                 ))
 
+  if(is.character(conv_opts$limit_vars) & length(conv_opts$limit_vars) > 0){
+    limit_vars <- c(conv_opts$limit_vars, paste0(conv_opts$limit_vars, '_qc'))
+    vars <- vars[vars[['Output_variable']] %in% limit_vars, ]
+  }
+
 
   #Read site information (lon, lat, elevation)
   site_info <- get_site_metadata(site_code)
@@ -692,7 +697,8 @@ get_default_conversion_options <- function() {
         check_range_action = "stop",
         include_all_eval = TRUE,
         aggregate = NA,
-        model = NA
+        model = NA,
+        limit_vars = c()
         )
 
     return(conv_opts)

--- a/R/ConvertSpreadsheetToNcdf.R
+++ b/R/ConvertSpreadsheetToNcdf.R
@@ -720,7 +720,7 @@ get_default_conversion_options <- function() {
         include_all_eval = TRUE,
         aggregate = NA,
         model = NA,
-        limit_vars = c()
+        limit_vars = NA
         )
 
     return(conv_opts)

--- a/R/Gapfilling.R
+++ b/R/Gapfilling.R
@@ -22,8 +22,9 @@ GapfillMet_with_ERA <- function(datain, ERA_file, qc_name, varnames, site_log, .
   vpd_units  <- datain$units$original_units[varnames$vpd]
   
   #If not found, set to unknown
-  if(length(tair_units)==0){ tair_units = "UNKNOWN" } 
-  if(length(vpd_units)==0){ vpd_units = "UNKNOWN" }
+  if (is.na(tair_units) | length(tair_units) == 0){ tair_units = "UNKNOWN" }
+  #If not found, assume hectopascals
+  if (is.na(vpd_units) | length(vpd_units) == 0){ vpd_units = "hPa" }
   
   #Gapfill met variables
   temp_data <- gapfill_with_ERA(datain=datain$data[,ind], era_data=era_data,

--- a/R/Gapfilling.R
+++ b/R/Gapfilling.R
@@ -9,7 +9,7 @@
 
 #' Gapfills meteorological data with down-scaled ERAinterim estimates
 #' @export
-GapfillMet_with_ERA <- function(datain, ERA_file, qc_name, varnames, ...){
+GapfillMet_with_ERA <- function(datain, ERA_file, qc_name, varnames, site_log, ...){
   
   #Read ERA data and extract time steps corresponding to obs
   era_data <- read_era(ERA_file=ERA_file, datain=datain)

--- a/R/Plotting.R
+++ b/R/Plotting.R
@@ -17,6 +17,12 @@ plot_nc <- function(ncfile, analysis_type, vars, varnames, outfile){
   #Initialise warnings
   warnings <- ""
   
+  vars <- na.omit(sapply(vars, function(x) { if (x %in% names(ncfile$var)) x }))
+  if (length(attr(vars, 'na.action')) > 0) {
+      warn("Some variables missing from netcdf file: ", attr(vars, 'na.action'))
+  }
+  vars <- unlist(vars)
+
   #Separate data and QC variables
   #TODO: hard coding "_qc" here, need to change
   data_vars <- vars[!grepl("_qc", vars)]

--- a/R/Site_metadata.R
+++ b/R/Site_metadata.R
@@ -143,7 +143,7 @@ get_site_metadata_from_CSV <- function(metadata=NA) {
     csv_data <- read.csv(site_csv_file, header = TRUE,
                     stringsAsFactors = FALSE)
 
-    if (is.na(metadata)) {
+    if (is.na(metadata[1])) {  # [1] to skip if site_code is set
         # get all existing metadata as a list of lists
         message("Loading metadata for all sites from csv_data cache (", site_csv_file, ")")
         metadata <- lapply(row.names(csv_data), function(row) {


### PR DESCRIPTION
This branch allows output files to be limited to fewer variables, so that un-neccesary variables are not taking up space.

The user just needs to modify the `conv_opts$limit_vars` variable to contain a list of output variable names.

The plot functions skip any variables that are not available in the netcdf files.