### PR TITLE
Simpler metadata checks

### DIFF
--- a/R/ConvertSpreadsheetToNcdf.R
+++ b/R/ConvertSpreadsheetToNcdf.R
@@ -152,7 +152,15 @@ convert_fluxnet_to_netcdf <- function(site_code, infile, era_file=NA, out_path,
 
 
   #Read site information (lon, lat, elevation)
-  site_info <- get_site_metadata(site_code)
+  if (conv_opts$metadata_source == 'all') {
+      site_info <- get_site_metadata(site_code)
+  } else if (conv_opts$metadata_source == 'csv') {
+      site_info <- get_site_metadata_from_CSV(site_code)
+  } else if (conv_opts$metadata_source == 'web') {
+      site_info <- get_site_metadata_web(site_code)
+  } else {
+      stop("Unknown metadata source '", conv_opts$metadata_source, "'")
+  }
   
   #Log possible warnings and remove warnings from output var
   site_log  <- log_warning(warn=site_info$warn, site_log)
@@ -698,6 +706,8 @@ convert_fluxnet_to_netcdf <- function(site_code, infile, era_file=NA, out_path,
 #' - model: Name of land surface model. Used to retrieve model specific attributes, such as site
 #'        plant functional type.
 #'
+#' - metadata_source: Sources to check for metadata. One of 'all', 'csv', or 'web'.
+#'
 #' @export
 #'
 get_default_conversion_options <- function() {
@@ -723,7 +733,8 @@ get_default_conversion_options <- function() {
         include_all_eval = TRUE,
         aggregate = NA,
         model = NA,
-        limit_vars = NA
+        limit_vars = NA,
+        metadata_source = 'all'
         )
 
     return(conv_opts)

--- a/man/CreateFluxNetcdfFile.Rd
+++ b/man/CreateFluxNetcdfFile.Rd
@@ -6,7 +6,7 @@
 \usage{
 CreateFluxNetcdfFile(fluxfilename, datain, site_code, siteInfo, ind_start,
   ind_end, starttime, flux_varname, cf_name, total_missing, total_gapfilled,
-  qcInfo, arg_info, var_ind, modelInfo)
+  qcInfo, arg_info, var_ind, varnames, modelInfo)
 }
 \description{
 Creates a netcdf file for flux variables

--- a/man/CreateMetNetcdfFile.Rd
+++ b/man/CreateMetNetcdfFile.Rd
@@ -6,7 +6,7 @@
 \usage{
 CreateMetNetcdfFile(metfilename, datain, site_code, siteInfo, ind_start,
   ind_end, starttime, flux_varname, cf_name, av_precip = NA, total_missing,
-  total_gapfilled, qcInfo, arg_info, var_ind, modelInfo)
+  total_gapfilled, qcInfo, arg_info, var_ind, varnames, modelInfo)
 }
 \description{
 Creates a netcdf file for met variables

--- a/man/get_default_conversion_options.Rd
+++ b/man/get_default_conversion_options.Rd
@@ -59,6 +59,7 @@ excess of the thresholds will be discarded.
 a maximum 24 hours (daily). Defaults to NA (no aggregation).
 \item model: Name of land surface model. Used to retrieve model specific attributes, such as site
 plant functional type.
+\item metadata_source: Sources to check for metadata. One of 'all', 'csv', or 'web'.
 }
 }
 \description{

--- a/man/get_site_metadata_from_CSV.Rd
+++ b/man/get_site_metadata_from_CSV.Rd
@@ -4,7 +4,7 @@
 \alias{get_site_metadata_from_CSV}
 \title{Tries to gather metadata from the included site CSV}
 \usage{
-get_site_metadata_from_CSV(metadata = NA)
+get_site_metadata_from_CSV(metadata = NA, incl_processing = TRUE)
 }
 \value{
 metadata list

--- a/man/get_site_metadata_web.Rd
+++ b/man/get_site_metadata_web.Rd
@@ -4,7 +4,7 @@
 \alias{get_site_metadata_web}
 \title{Tries to load metadata from known Fluxnet info sources on the 'web}
 \usage{
-get_site_metadata_web(metadata)
+get_site_metadata_web(metadata, incl_processing = TRUE)
 }
 \value{
 metadata list


### PR DESCRIPTION
This allows the user to specify which sources of metadata to check: 

- `all`: CSV and web together
- `csv`: CSV only
- `web`: web sources only